### PR TITLE
Feature/user login 19- 顧客-ログイン機能

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,3 +17,8 @@
 @import "font-awesome-sprockets";
 @import "font-awesome";
 
+footer{
+  width: 100%; /*画面幅いっぱいに広げる*/
+  position: absolute;/*←絶対位置*/
+  bottom: 0; /*下に固定*/
+}

--- a/app/views/customers/passwords/new.html.erb
+++ b/app/views/customers/passwords/new.html.erb
@@ -1,16 +1,14 @@
 <h2>Forgot your password?</h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "customers/shared/error_messages", resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :メールアドレス %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
+    <%= f.submit "パスワード再設定用URLを送信" %>
   </div>
 <% end %>
 
-<%= render "customers/shared/links" %>

--- a/app/views/customers/registrations/new.html.erb
+++ b/app/views/customers/registrations/new.html.erb
@@ -1,7 +1,6 @@
 <h2>サインアップ</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "customers/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :email %><br />
@@ -26,5 +25,4 @@
   </div>
 <% end %>
 
-<%= render "customers/shared/links" %>
 

--- a/app/views/customers/sessions/new.html.erb
+++ b/app/views/customers/sessions/new.html.erb
@@ -2,33 +2,64 @@
   <div class="row justify-content-center">
     <div class="col-7">
 
-<div class="text-center mt-5">会員の方はこちらからログイン</div>
+      <div class="col-md-6,text-center mt-5">
+        <span class="title">
+          会員の方はこちらからログイン
+        </span>
+      </div>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :メールアドレス %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <div class="text-center mt-5">
+        <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+        <div class="field">
+          <%= f.label :メールアドレス %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        </div>
+      </div>
+      
+      <div class="text-center mt-4">
+        <div class="field">
+          <%= f.label :パスワード %>
+          <%= f.password_field :password, autocomplete: "current-password" %>
+        </div>
+      </div>
 
-  <div class="field">
-    <%= f.label :パスワード %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+      <div class="text-center mt-4">
+        <div class="remember">
+          <%= link_to '=>パスワードを忘れた方はこちら',new_customer_password_path %>
+        </div>
+      </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+      <div class="text-center mt-4">
+        <div class="actions">
+          <%= f.submit "ログイン",class: 'btn btn-sm btn-primary' %>
+        </div>
+      </div>
+      <% end %>
+
+      <p>
+        <div class="col-md-6,text-center mt-5">
+          <span class="title">
+            登録がお済みでない方
+          </span>
+        </div>
+      </p>
+
+      <div class="text-center mt-4">
+        <div class="signup-info">
+          <%= link_to 'こちら',new_customer_registration_path %> から新規登録を行ってください。
+        </div>
+      </div>
+
+
     </div>
-  <% end %>
-  <%= link_to '=>パスワードを忘れた方はこちら',new_customer_password_path %>
-
-
-  <div class="actions">
-    <%= f.submit "ログイン" %>
   </div>
-<% end %>
+</div>
 
-</div>
-</div>
-</div>
+
+
+<style>
+  .title {
+    background-color: #ff6e6e;
+    color: #ffff;
+  }
+</style>

--- a/app/views/customers/sessions/new.html.erb
+++ b/app/views/customers/sessions/new.html.erb
@@ -1,13 +1,17 @@
-<h2>Log in</h2>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="col-7">
+
+<div class="text-center mt-5">会員の方はこちらからログイン</div>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :メールアドレス %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
+    <%= f.label :パスワード %><br />
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 
@@ -17,10 +21,14 @@
       <%= f.label :remember_me %>
     </div>
   <% end %>
+  <%= link_to '=>パスワードを忘れた方はこちら',new_customer_password_path %>
+
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "ログイン" %>
   </div>
 <% end %>
 
-<%= render "customers/shared/links" %>
+</div>
+</div>
+</div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -7,3 +7,5 @@
     </div>
   </div>
 </footer>
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,7 @@ Rails.application.routes.draw do
   scope module: 'customer' do
     root 'homes#top'
     get 'about' => 'homes#about'
-    resource :users, only: [:show, :edit, :update, :destroy] do
-      get 'exit' => 'users#exit'
-    end
   end
+
+
 end


### PR DESCRIPTION
### 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#2 
ログイン画面のバランスを大まかに整えました。
<img width="1430" alt="スクリーンショット 2020-12-16 15 31 31" src="https://user-images.githubusercontent.com/71075728/102313338-cc0c8300-3fb3-11eb-9373-9b086257533c.png">

### 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
ログイン画面のバランスを大まかに整えました。
フッターを画面下に固定させるようにしました。
### 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
とりあえずで配置しただけなので、結構不恰好ですが、最後に他のページとのバランスを見ながら修正します。