### PR TITLE
Feature/manage delivery

### DIFF
--- a/app/assets/javascripts/customer/delivery_addresses.coffee
+++ b/app/assets/javascripts/customer/delivery_addresses.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/customer/delivery_addresses.scss
+++ b/app/assets/stylesheets/customer/delivery_addresses.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the customer::deliveryAddresses controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/customer/delivery_addresses_controller.rb
+++ b/app/controllers/customer/delivery_addresses_controller.rb
@@ -1,0 +1,46 @@
+class Customer::DeliveryAddressesController < ApplicationController
+
+  def index
+    @delivery_address = DeliveryAddress.new
+    @delivery_addresses = current_customer.delivery_addresses
+  end
+
+  def create
+    # 非同期処理の実行
+    @delivery_address = current_customer.delivery_addresses.build(delivery_address_params)
+    @delivery_address.save
+    @delivery_addresses = current_customer.delivery_addresses
+    respond_to do |format|
+      format.html { redirect_back(fallback_location: root_path) }
+      format.js
+    end
+  end
+
+  def edit
+    @delivery_address = current_customer.delivery_addresses.find(params[:id])
+  end
+
+  def update
+    @delivery_address = current_customer.delivery_addresses.find(params[:id])
+    if @delivery_address.update(delivery_address_params)
+      redirect_to delivery_addresses_path
+    else
+      render :edit
+    end
+  end
+  
+  def destroy
+    delivery_address = current_customer.delivery_addresses.find(params[:id])
+    delivery_address.destroy
+    @delivery_addresses = current_customer.delivery_addresses
+    respond_to do |format|
+      format.html { redirect_back(fallback_location: root_path) }
+      format.js
+    end
+  end
+
+  def delivery_address_params
+    params.require(:delivery_address).permit(:name, :post_code, :address)
+  end
+
+end

--- a/app/helpers/customer/delivery_addresses_helper.rb
+++ b/app/helpers/customer/delivery_addresses_helper.rb
@@ -1,0 +1,2 @@
+module Customer::DeliveryAddressesHelper
+end

--- a/app/views/customer/delivery_addresses/_address-list.html.erb
+++ b/app/views/customer/delivery_addresses/_address-list.html.erb
@@ -1,0 +1,22 @@
+<table class="table mt-5">
+  <thead>
+    <tr>
+      <th scope="col" class="w-25">郵便番号</th>
+      <th scope="col" class="w-25">住所</th>
+      <th scope="col" class="w-25">宛名</th>
+      <th scope="col"></th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% delivery_addresses.each do |delivery_address| %>
+      <tr>
+        <td><%= delivery_address.post_code %></td>
+        <td><%= delivery_address.address %></td>
+        <td><%= delivery_address.name %></td>
+        <td><%= link_to "編集", edit_delivery_address_path(delivery_address.id), class: "btn btn-primary" %></td>
+        <td><%= link_to "削除", delivery_address_path(delivery_address.id), method: :delete, class: "btn btn-danger", data: {confirm: "本当に削除しますか？"} %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/customer/delivery_addresses/create.js.erb
+++ b/app/views/customer/delivery_addresses/create.js.erb
@@ -1,0 +1,4 @@
+$("#delivery_address-list").html("<%= escape_javascript(render 'address-list', delivery_addresses: @delivery_addresses) %>");
+$("#delivery_post_code__input").val('');
+$("#delivery_address__input").val('');
+$("#delivery_name__input").val('');

--- a/app/views/customer/delivery_addresses/destroy.js.erb
+++ b/app/views/customer/delivery_addresses/destroy.js.erb
@@ -1,0 +1,1 @@
+$("#delivery_address-list").html("<%= escape_javascript(render 'address-list', delivery_addresses: @delivery_addresses) %>");

--- a/app/views/customer/delivery_addresses/edit.html.erb
+++ b/app/views/customer/delivery_addresses/edit.html.erb
@@ -1,0 +1,49 @@
+<div class="container">
+  <div class="row">
+    <div class="col-9">
+      <h2 class="mt-5">配送先編集</h2>
+      <!-- 編集エラー時の処理 -->
+      <% if @delivery_address.errors.present? %>
+        <div class="alert alert-danger" role="alert">
+          <ul>
+            <% @delivery_address.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+      <%= form_with model: @delivery_address, local: true do |f| %>
+        <table class="mt-5">
+          <thead>
+            <tr>
+              <th clsss="w-25"></th>
+              <th class="w-25"></th>
+              <th class="w-50"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><label for="delivery_post_code__input">郵便番号（ハイフンなし）</label></td>
+              <td><%= f.text_field :post_code, autofocus: true, id: "delivery_post_code__input", class: "form-control" %></td>
+            </tr>
+            <tr>
+              <td><label for="delivery_address__input">住所</label></td>
+              <td colspan="2"><%= f.text_field :address, autofocus: true, id: "delivery_address__input", class: "form-control" %></td>
+            </tr>
+            <tr>
+              <td><label for="delivery_name__input">宛名</label></td>
+              <td><%= f.text_field :name, autofocus: true, id: "delivery_name__input", class: "form-control" %></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="container mt-5">
+          <div class="row justify-content-center">
+            <div class="text-center col-5">
+              <%= f.submit "編集する", class: "btn btn-success" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/customer/delivery_addresses/index.html.erb
+++ b/app/views/customer/delivery_addresses/index.html.erb
@@ -1,0 +1,42 @@
+<div class="container">
+  <div class="row">
+    <div class="col-9">
+      <h2 class="mt-5">配送先登録/一覧</h2>
+      <%= form_with model: @delivery_address, remote: true do |f| %>
+        <table class="mt-5">
+          <thead>
+            <tr>
+              <th clsss="w-25"></th>
+              <th class="w-25"></th>
+              <th class="w-50"></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><label for="delivery_post_code__input">郵便番号（ハイフンなし）</label></td>
+              <td><%= f.text_field :post_code, autofocus: true, id: "delivery_post_code__input", class: "form-control" %></td>
+            </tr>
+            <tr>
+              <td><label for="delivery_address__input">住所</label></td>
+              <td colspan="2" class="mw-100"><%= f.text_field :address, autofocus: true, id: "delivery_address__input", class: "form-control" %></td>
+            </tr>
+            <tr>
+              <td><label for="delivery_name__input">宛名</label></td>
+              <td><%= f.text_field :name, autofocus: true, id: "delivery_name__input", class: "form-control" %></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="container mt-3">
+          <div class="row justify-content-center">
+            <div class="text-center col-5">
+              <%= f.submit "登録する", class: "btn btn-success" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+      <div id="delivery_address-list">
+        <%= render 'address-list', delivery_addresses: @delivery_addresses %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,5 +19,6 @@ Rails.application.routes.draw do
     resource :users, only: [:show, :edit, :update, :destroy] do
       get 'exit' => 'users#exit'
     end
+    resources :delivery_addresses, only: [:index, :create, :edit, :update, :destroy]
   end
 end

--- a/test/controllers/customer/delivery_addresses_controller_test.rb
+++ b/test/controllers/customer/delivery_addresses_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Customer::DeliveryAddressesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要

顧客の配送先一覧を表示、非同期で新規登録、配送先編集画面の作成と編集機能、削除機能を追加しました。

### 変更内容

* 顧客の配送先一覧画面を追加
<img width="943" alt="delivery_address_index" src="https://user-images.githubusercontent.com/42575165/102314391-b6985880-3fb5-11eb-9e2c-cd5e11ff9013.png">
* 顧客の配送先一覧をパーシャルで追加（非同期実行時に更新されるテンプレート）
* 登録ボタン押下時に非同期で新規登録処理を実行し配送先一覧を更新する
* 配送先編集画面を追加
<img width="864" alt="delivery_address_edit" src="https://user-images.githubusercontent.com/42575165/102314589-0d059700-3fb6-11eb-84d6-0e8853f68386.png">
* 配送先一覧画面から削除ボタンを押下時に非同期で削除処理を実行し配送先一覧テンプレートを更新する

### 補足
* 特に非同期処理の実装をご確認ください。

