### PR TITLE
Update/ログイン状態によって変わるようにしました

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -2,14 +2,25 @@
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
 
-         <a class="navbar-brand" href="/"><span>Nagano cake</span></a>
+      <a class="navbar-brand" href="/"><span>Nagano cake</span></a>
 
+
+      <div class="collapse navbar-collapse" id="navbarNavDropdown">
         <ul class="navbar-nav ml-auto">
-          <li class='nav-link text-light'>About</li>
-          <li class='nav-link text-light'>商品一覧</li>
-          <li class='nav-link text-light'>新規登録</li>
-          <li class='nav-link text-light'>ログイン</li>
-        </ul>
-    </div>
+          <% if customer_signed_in? %>
+          <li> <%= link_to'マイページ',root_path,class: 'far fa-user-circle nav-link text-light' %></li>
+          <li> <%= link_to"商品一覧",root_path,class: "fas fa-birthday-cake nav-link text-light" %></li>
+          <li> <%= link_to"カート",root_path,class: "fas fa-cart-plus nav-link text-light" %> </li>
+          <li> <%= link_to"ログアウト",destroy_user_session_path, method: :delete,class: "fas fa-sign-out-alt nav-link text-light"%></li>
+          <% else %>
+          <li> <%= link_to'About',about_path,class: 'fas fa-atlas nav-link text-light' %></li>
+          <li> <%= link_to"商品一覧",root_path,class: "fas fa-birthday-cake nav-link text-light" %></li>
+          <li> <%= link_to"新規登録",new_customer_registration_path,class: "fas fa-user-plus nav-link text-light" %></li>
+          <li> <%= link_to"ログイン",new_customer_session_path,class: "fas fa-user nav-link text-light" %></li>
+          <% end %>
+          </ul>
+<%# まだページがないもの、routesがない物はとりあえずでルートパスに指定してます。完成次第修正要 %>
+
+      </div>
   </nav>
 </header>


### PR DESCRIPTION
### 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#20 
顧客-ログイン状態によって変わるようにしました
### 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
<img width="1426" alt="スクリーンショット 2020-12-16 17 38 17" src="https://user-images.githubusercontent.com/71075728/102324669-822c9880-3fc5-11eb-96af-23a78f290559.png">
<img width="1427" alt="スクリーンショット 2020-12-16 17 49 44" src="https://user-images.githubusercontent.com/71075728/102325924-18ad8980-3fc7-11eb-9f73-bb1d66e4a102.png">

### 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
現状「サインアップ」「ログイン」「about」リンク以外は`root_paht`でしています。
ページが完成次第修正します。