### PR TITLE
管理者画面の会員情報一覧/詳細/編集画面

### DIFF
--- a/app/assets/javascripts/admin/users.coffee
+++ b/app/assets/javascripts/admin/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admin/users.scss
+++ b/app/assets/stylesheets/admin/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin::users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,8 +17,8 @@
 @import "font-awesome-sprockets";
 @import "font-awesome";
 
-footer{
-  width: 100%; /*画面幅いっぱいに広げる*/
-  position: absolute;/*←絶対位置*/
-  bottom: 0; /*下に固定*/
-}
+// footer{
+//   width: 100%; /*画面幅いっぱいに広げる*/
+//   position: absolute;/*←絶対位置*/
+//   bottom: 0; /*下に固定*/
+// }

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -23,7 +23,7 @@ class Admin::UsersController < ApplicationController
   end
 
   def customer_params
-    params.require(:customer).permit(:family_name, :first_name, :family_name_kana, :first_name_name,
+    params.require(:customer).permit(:family_name, :first_name, :family_name_kana, :first_name_kana,
                   :post_code, :address, :phone_number, :email, :is_active)
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,30 @@
+class Admin::UsersController < ApplicationController
+
+  def index
+    # TODO: デフォルトで何件表示するかは要検討
+    @customers = Customer.all.page(params[:page]).per(10)
+  end
+
+  def show
+    @customer = Customer.find(params[:id])
+  end
+
+  def edit
+    @customer = Customer.find(params[:id])
+  end
+
+  def update
+    @customer = Customer.find(params[:id])
+    if @customer.update(customer_params)
+      redirect_to admin_user_path(@customer)
+    else
+      render :edit
+    end
+  end
+
+  def customer_params
+    params.require(:customer).permit(:family_name, :first_name, :family_name_kana, :first_name_name,
+                  :post_code, :address, :phone_number, :email, :is_active)
+  end
+
+end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -20,4 +20,8 @@ class Customer < ApplicationRecord
   validates :post_code, presence: true
   validates :address, presence: true
   validates :phone_number, presence: true
+
+  def full_name
+    self.family_name + self.first_name
+  end
 end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,77 @@
+<div class="container">
+  <div class="row">
+    <div class="col-9">
+      <h2 class="mt-5"><%= @customer.full_name %>さんの会員情報編集</h2>
+      <!-- TODO: 編集エラー時の処理 -->
+      <% if @customer.errors.present? %>
+        <div class="alert alert-danger" role="alert">
+          <ul>
+            <% @customer.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+      <%= form_with model: @customer, url: admin_user_path, local: true do |f| %>
+        <table class="mt-5">
+          <thead>
+            <tr>
+              <th width="150"></th>
+              <th></th>
+              <th></th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>会員ID</td>
+              <td><%= @customer.id %></td>
+            </tr>
+            <tr>
+              <td>氏名</td>
+              <td><%= f.text_field :family_name, autofocus: true, class: "form-control" %></td>
+              <td><%= f.text_field :first_name, autofocus: true, class: "form-control" %></td>
+            </tr>
+            <tr>
+              <td>フリガナ</td>
+              <td><%= f.text_field :family_name_kana, autofocus: true, class: "form-control" %></td>
+              <td><%= f.text_field :first_name_kana, autofocus: true, class: "form-control" %></td>
+            </tr>
+            <tr>
+              <td>郵便番号</td>
+              <td><%= f.text_field :post_code, autofocus: true, class: "form-control" %></td>
+            </tr>
+            <tr>
+              <td>住所</td>
+              <td colspan="3"><%= f.text_field :address, autofocus: true, class: "form-control" %></td>
+            </tr>
+            <tr>
+              <td>電話番号</td>
+              <td><%= f.text_field :phone_number, autofocus: true, class: "form-control" %></td>
+            </tr>
+            <tr>
+              <td>メールアドレス</td>
+              <td><%= f.text_field :email, autofocus: true, class: "form-control" %></td>
+            </tr>
+            <tr>
+              <td>会員ステータス</td>
+              <td>
+                <%= f.radio_button :is_active, true, class: "d-inline-block" %>
+                <%= f.label :is_active, "有効", {value: true, style: "display: inline-block;"} %>
+                <%= f.radio_button :is_active, false, class: "d-inline-block" %>
+                <%= f.label :is_active, "退会済み", {value: false, style: "display: inline-block;"} %>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="container mt-5">
+          <div class="row justify-content-center">
+            <div class="col-5">
+              <%= f.submit "変更を保存する", class: "btn btn-primary" %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,30 @@
+<div class="container">
+  <div class="row">
+    <div class="col-9">
+      <h2 class="mt-5">会員一覧</h2>
+      <div class="mt-5">
+        <table class="table mt-5">
+          <thead>
+            <tr>
+              <th scope="col">会員ID</th>
+              <th scope="col">氏名</th>
+              <th scope="col">メールアドレス</th>
+              <th scope="col">ステータス</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @customers.each do |customer| %>
+              <tr>
+                <td><%= customer.id %></td>
+                <td><%= link_to "#{customer.family_name + customer.first_name}", admin_user_path(customer.id) %></td>
+                <td><%= customer.email %></td>
+                <td><%= customer.is_active ? "有効" : "無効" %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+        <%= paginate @customers %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,55 @@
+<div class="container">
+  <div class="row">
+    <div class="col-9">
+      <h2 class="mt-5"><%= @customer.full_name %>さんの会員詳細</h2>
+      <div class="mt-5">
+        <table class="table mt-5">
+          <tbody>
+            <tr>
+              <th>顧客ID</th>
+              <td><%= @customer.id %>
+                <% if @customer.is_active %>
+                  <span class="badge badge-primary">有効会員<span>
+                <% else %>
+                  <span class="badge badge-secondary">無効会員<span>
+                <% end %>
+              </td>
+            </tr>
+            <tr>
+              <th>氏名</th>
+              <td><%= @customer.family_name %>&nbsp;&nbsp;<%= @customer.first_name %></td>
+            </tr>
+            <tr>
+              <th>フリガナ</th>
+              <td><%= @customer.family_name_kana %>&nbsp;&nbsp;<%= @customer.first_name_kana %></td>
+            </tr>
+            <tr>
+              <th>郵便番号</th>
+              <td><%= @customer.post_code %></td>
+            </tr>
+            <tr>
+              <th>住所</th>
+              <td><%= @customer.address %></td>
+            </tr>
+            <tr>
+              <th>電話番号</th>
+              <td><%= @customer.phone_number %></td>
+            </tr>
+            <tr>
+              <th>メールアドレス</th>
+              <td><%= @customer.email %></td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="container mt-3">
+          <div class="row">
+            <div class="text-center col-5">
+              <%= link_to "編集する", edit_admin_user_path(@customer.id), class: "btn btn-primary" %>
+              <%= link_to "注文履歴一覧を見る", admin_orders_path, class: "btn btn-primary" %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
     resources :orders, only: [:index, :show, :update] do
       resources :order_products, only: [:update]
     end
+    resources :users, only: [:index, :show, :edit, :update]
   end
 
   scope module: 'customer' do

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要

管理者画面で会員情報の一覧及び詳細の閲覧、編集が行えるように実装しました。

### 変更内容
* 会員情報一覧画面の作成
<img width="957" alt="admin_user_index" src="https://user-images.githubusercontent.com/42575165/102380990-01dd5600-400c-11eb-9ee6-10c3a8090c4c.png">
* 会員情報詳細画面の作成
<img width="810" alt="admin_user_show" src="https://user-images.githubusercontent.com/42575165/102381069-1c173400-400c-11eb-8a26-ecfd122d7314.png">
* 会員情報編集画面の作成
<img width="735" alt="admin_user_edit" src="https://user-images.githubusercontent.com/42575165/102381109-29ccb980-400c-11eb-9b89-d2b17c81b70d.png">
* 会員情報編集機能の実装

### 補足
特段特殊な処理は入れてないです。
