### PR TITLE
[update]管理者の注文履歴一覧画面の注文ステータスの表示を更新

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -27,30 +27,15 @@ class Order < ApplicationRecord
     order_product_amount
   end
 
-  # def display_work_status
-  #   # work_statusに応じて表示を分ける
-  #   case self.order_status
-  #   when 0
-  #     "着手不可"
-  #   when 1
-  #     "製作待ち"
-  #   when 2
-  #     "制作中"
-  #   when 3
-  #     "製作完了"
-  #   else
-  #     "着手不可"
-  #   end
-  # end
-
   def display_order_status
+    # 注文ステータスを表示する関数
     case self.order_status
     when 0
       "入金待ち"
     when 1
       "入金確認"
     when 2
-      "作成中"
+      "制作中"
     when 3
       "発送準備中"
     else

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -18,7 +18,7 @@
                 <td><%= link_to "#{order.created_at.strftime('%Y/%m/%d %H:%M:%S')}", admin_order_path(order.id) %></td>
                 <td><%= order.customer.family_name + order.customer.first_name %></td>
                 <td><%= order.amount %></td>
-                <td><%= order.display_work_status %></td>
+                <td><%= order.display_order_status %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -24,7 +24,7 @@
                   <th>注文ステータス</th>
                   <td>
                     <%= form_with method: @order, url: admin_order_path(@order.id), method: :patch, remote: true do |f| %>
-                      <%= f.select :order_status, [['入金待ち', 0], ['入金確認', 1], ['制作中', 2], ['発送準備中', 3], ['発送済み', 4]], { selected: @order.order_status }, class: "form-control w-25 d-inline-block" %>
+                      <%= f.select :order_status, [['入金待ち', 0], ['入金確認', 1], ['製作中', 2], ['発送準備中', 3], ['発送済み', 4]], { selected: @order.order_status }, class: "form-control w-25 d-inline-block" %>
                       <%= f.submit "更新", class: "btn btn-primary" %>
                     <% end %>
                   </td>
@@ -57,7 +57,7 @@
                     <td><%= order_product.subtotal %></td>
                     <td>
                       <%= form_with method: order_product, url: admin_order_order_product_path(@order.id, order_product.id), method: :patch, remote: true do |f| %>
-                        <%= f.select :work_status, [['着手不可', 0], ['製作待ち', 1], ['制作中', 2], ['制作完了', 3]], { selected: order_product.work_status }, class: "form-control w-50 d-inline-block" %>
+                        <%= f.select :work_status, [['着手不可', 0], ['製作待ち', 1], ['製作中', 2], ['製作完了', 3]], { selected: order_product.work_status }, class: "form-control w-50 d-inline-block" %>
                         <%= f.submit "更新", class: "btn btn-primary" %>
                       <% end %>
                     </td>


### PR DESCRIPTION
### 概要

管理者の注文履歴一覧画面の注文ステータスを更新しました。

### 変更内容

* 注文ステータスのviewがdisplay_work_statusを参照していましたが、display_order_statusを参照するように変更しました。併せて製作中の漢字を修正しています。

### 補足

