### PR TITLE
Fix/header

### DIFF
--- a/app/views/layouts/_customers_header.html.erb
+++ b/app/views/layouts/_customers_header.html.erb
@@ -1,0 +1,27 @@
+<header>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container">
+
+      <a class="navbar-brand" href="/"><span>Nagano cake</span></a>
+
+
+      <div class="collapse navbar-collapse" id="navbarNavDropdown">
+        <ul class="navbar-nav ml-auto">
+          <% if customer_signed_in? %>
+          <li> <%= link_to'マイページ',users_path,class: 'far fa-user-circle nav-link text-light' %></li>
+          <li> <%= link_to"商品一覧",products_path,class: "fas fa-birthday-cake nav-link text-light" %></li>
+          <li> <%= link_to"カート",cart_products_path,class: "fas fa-cart-plus nav-link text-light" %> </li>
+          <li> <%= link_to"ログアウト",destroy_customer_session_path, method: :delete,class: "fas fa-sign-out-alt nav-link text-light"%></li>
+          <% else %>
+          <li> <%= link_to'About',about_path,class: 'fas fa-atlas nav-link text-light' %></li>
+          <li> <%= link_to"商品一覧",products_path,class: "fas fa-birthday-cake nav-link text-light" %></li>
+          <li> <%= link_to"新規登録",new_customer_registration_path,class: "fas fa-user-plus nav-link text-light" %></li>
+          <li> <%= link_to"ログイン",new_customer_session_path,class: "fas fa-user nav-link text-light" %></li>
+          <% end %>
+        </ul>
+        
+<%# まだページがないもの、routesがない物はとりあえずでルートパスに指定してます。完成次第修正要 %>
+
+      </div>
+  </nav>
+</header>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -11,7 +11,7 @@
           <li> <%= link_to'マイページ',root_path,class: 'far fa-user-circle nav-link text-light' %></li>
           <li> <%= link_to"商品一覧",root_path,class: "fas fa-birthday-cake nav-link text-light" %></li>
           <li> <%= link_to"カート",root_path,class: "fas fa-cart-plus nav-link text-light" %> </li>
-          <li> <%= link_to"ログアウト",destroy_user_session_path, method: :delete,class: "fas fa-sign-out-alt nav-link text-light"%></li>
+          <li> <%= link_to"ログアウト",destroy_customer_session_path, method: :delete,class: "fas fa-sign-out-alt nav-link text-light"%></li>
           <% else %>
           <li> <%= link_to'About',about_path,class: 'fas fa-atlas nav-link text-light' %></li>
           <li> <%= link_to"商品一覧",root_path,class: "fas fa-birthday-cake nav-link text-light" %></li>


### PR DESCRIPTION
### 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#48  ヘッダーの遷移先を変更
### 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
今までヘッダーの遷移先「マイページ」「カート」はroot_pathでしたが、該当のページに遷移できるように変更ました。
### 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
動作確認はOKdでした。