### PR TITLE
[Update} 注文確認画面

### DIFF
--- a/app/assets/stylesheets/customer/orders.scss
+++ b/app/assets/stylesheets/customer/orders.scss
@@ -1,3 +1,24 @@
 // Place all the styles related to the customer::orders controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+.c-order-button{
+  display: inline-block;
+  border-radius: 5%;
+  /* 角丸       */
+  font-size: 12pt;
+  /* 文字サイズ */
+  text-align: center;
+  /* 文字位置   */
+  cursor: pointer;
+  /* カーソル   */
+  padding: 9px 33px;
+  /* 余白       */
+  background: #000000;
+  /* 背景色     */
+  color: #C8A06B;
+  /* 文字色     */
+  line-height: 1em;
+  /* 1行の高さ  */
+  transition: .3s;
+  /* なめらか変化 */
+}

--- a/app/assets/stylesheets/customer/orders.scss
+++ b/app/assets/stylesheets/customer/orders.scss
@@ -22,3 +22,10 @@
   transition: .3s;
   /* なめらか変化 */
 }
+.c-order-confirm{
+  background-color:#000000;
+  color: #C8A06B;
+}
+.c-order-confirm-index{
+  background-color:#EDE1D1;
+}

--- a/app/assets/stylesheets/customer/orders.scss
+++ b/app/assets/stylesheets/customer/orders.scss
@@ -1,7 +1,7 @@
 // Place all the styles related to the customer::orders controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
-.c-order-button{
+.c-order-button {
   display: inline-block;
   border-radius: 5%;
   /* 角丸       */
@@ -22,10 +22,22 @@
   transition: .3s;
   /* なめらか変化 */
 }
-.c-order-confirm{
-  background-color:#000000;
+
+.c-order-confirm {
+  background-color: #000000;
   color: #C8A06B;
 }
-.c-order-confirm-index{
-  background-color:#EDE1D1;
+
+.c-order-confirm-index {
+  background-color: #EDE1D1;
+}
+
+.c-order-thanks {
+  text-align: center;
+  padding: 8px 19px;
+  margin: 2em 0;
+  color: #2c2c2f;
+  background: #EDE1D1;
+  border-top: solid 5px #000000;
+  border-bottom: solid 5px #000000;
 }

--- a/app/views/customer/orders/confirm.html.erb
+++ b/app/views/customer/orders/confirm.html.erb
@@ -1,25 +1,25 @@
 <div class="container">
 
   <div class='row mt-3'>
-    <div class='col-3 offset-1'>
-      <h5 class='text-center'>注文情報確認</h5>
-    </div>
+    <%# <div class='col-3'> %>
+      <h4 class='text-center'>注文情報確認</h4>
+    <%# </div> %>
   </div>
 
   <div class='row mt-3'>
     <div class='col'>
-      <table class='table table-bordered border-primary'>
+      <table class='table'>
         <thead>
-          <tr>
-            <th class='table-secondary'>商品名</th>
-            <th class='table-secondary'>単価(税込)</th>
-            <th class='table-secondary'>数量</th>
-            <th class='table-secondary'>小計</th>
+          <tr class="c-order-confirm">
+            <th>商品名</th>
+            <th>単価(税込)</th>
+            <th>数量</th>
+            <th>小計</th>
           </tr>
         </thead>
         <tbody>
           <% @cart_products.each do |cart_product| %>
-            <tr>
+            <tr class="c-order-confirm-index">
               <td>
                 <% product = Product.find(cart_product.product_id) %>
                 <%= attachment_image_tag product, :image, size:'40x40', fallback: "sample.png" %>
@@ -36,19 +36,19 @@
 
     <div class='col'>
       <table class='table table-bordered border-primary'>
-        <tr>
-          <th class='table-secondary'>送料</th>
+        <tr class="c-order-confirm-index">
+          <th class='c-order-confirm'>送料</th>
           <td><%= @order.shipping.to_s(:delimited) %></td>
         </tr>
-        <tr>
-          <th class='table-secondary'>商品合計</th>
+        <tr class="c-order-confirm-index">
+          <th class='c-order-confirm'>商品合計</th>
           <td>
             <% total = get_total(@cart_products) %>
             <%= total.to_s(:delimited) %>
           </td>
         </tr>
-        <tr>
-          <th class='table-secondary'>請求金額</th>
+        <tr class="c-order-confirm-index">
+          <th class='c-order-confirm'>請求金額</th>
           <td><%= ( @order.shipping.to_i + total ).to_s(:delimited) %></td>
         </tr>
       </table>
@@ -87,7 +87,7 @@
     <div class='row mt-3'>
       <div class='col-12'>
         <div class='text-center'>
-          <%= f.submit "購入を確定する", class: "btn btn-success" %>
+          <%= f.submit "購入を確定する", class: "c-order-button" %>
         </div>
       </div>
     </div>

--- a/app/views/customer/orders/new.html.erb
+++ b/app/views/customer/orders/new.html.erb
@@ -1,79 +1,84 @@
 <div class="container">
   <div class='row mt-3'>
     <div class='col-3 offset-1'>
-      <h5 class='text-center'>注文情報入力</h5>
+      <h4 class='text-center'>注文情報入力</h4>
     </div>
   </div>
   <%= form_with model: @order, url: orders_confirm_path, local: true do |f| %>
-    <div class='row mt-3'>
-      <div class='col-3'>
-        <h5 class=''>支払方法</h5>
-      </div>
+  <div class='row mt-3'>
+    <div class='col-3'>
+      <h5>支払方法</h5>
     </div>
-    <div class='row'>
-      <div class='col-3 offset-1'>
-          <div>
-            <%= f.radio_button :payment_method, 1, {:checked => true} %>
-            <%= f.label :payment_method, "クレジットカード", {value: 1, style: "display: inline-block;"} %>
+  </div>
+  <div class='row'>
+    <div class='col-3 offset-1'>
+      <table>
+            <th><%= f.radio_button :payment_method, 1, {:checked => true} %></th>
+            <th><%= f.label :payment_method, "クレジットカード", {value: 1, style: "display: inline-block;"} %></th>
           </div>
           <div>
-            <%= f.radio_button :payment_method, 0 %>
-            <%= f.label :payment_method, "銀行振込", {value: 0, style: "display: inline-block;"} %>
+            <th><%= f.radio_button :payment_method, 0 %></th>
+            <th><%= f.label :payment_method, "銀行振込", {value: 0, style: "display: inline-block;"} %></th>
           </div>
+      </table>
+
+    </div>
+  </div>
+  <div class='row mt-3'>
+    <div class='col-3'>
+      <h5 class=''>お届け先</h5>
+    </div>
+  </div>
+  <div class='row'>
+    <div class='col offset-1'>
+    <table>  
+      <tbody> 
+      <div>
+        <%= f.radio_button :send_address, 0, {id: "radio_button_send_address_0", :checked => true} %>
+        <%= f.label :send_address, "ご自身の住所", {value: 0, style: "display: inline-block;"} %>
+      </div>
+      <div><%= current_customer.address %></div>
+      <div><%= get_fullname(current_customer) %></div>
+      <div>
+        <%= f.radio_button :send_address, 1, {id: "radio_button_send_address_1"} %>
+        <%= f.label :send_address, "登録済住所から選択", {value: 1, style: "display: inline-block;"} %>
+      </div>
+      <select name="registered_address">
+        <%= @delivery_addresses.each do |delivery_addresses| %>
+        <option value=<%= delivery_addresses.id %>>
+          <%= delivery_addresses.post_code + " " + delivery_addresses.address + " " + delivery_addresses.name %>
+        </option>
+        <% end %>
+      </select>
+      <div>
+        <%= f.radio_button :send_address, 2, {id: "radio_button_send_address_2"} %>
+        <%= f.label :send_address, "新しいお届け先", {value: 2, style: "display: inline-block;"} %>
+      </div>
+      <div>
+        <%# <table> %>
+          <tr>
+            <td><%= f.label :new_post_code, "郵便番号(ハイフンなし)" %></td>
+            <td><%= f.text_field :new_post_code, class: "form-control" %></td>
+          </tr>
+          <tr>
+            <td><%= f.label :new_address, "住所" %></td>
+            <td><%= f.text_field :new_address, class: "form-control" %></td>
+          </tr>
+          <tr>
+            <td><%= f.label :new_name, "宛先" %></td>
+            <td><%= f.text_field :new_name, class: "form-control" %></td>
+          </tr>
+          </tbody>
+        </table>
       </div>
     </div>
-    <div class='row mt-3'>
-      <div class='col-3'>
-        <h5 class=''>お届け先</h5>
+  </div>
+  <div class='row mt-3'>
+    <div class='col-12'>
+      <div class='text-center'>
+        <%= f.submit "確認画面へ進む", class: "c-order-button" %>
       </div>
     </div>
-    <div class='row'>
-      <div class='col offset-1'>
-        <div>
-          <%= f.radio_button :send_address, 0, {id: "radio_button_send_address_0", :checked => true} %>
-          <%= f.label :send_address, "ご自身の住所", {value: 0, style: "display: inline-block;"} %>
-        </div>
-        <div><%= current_customer.address %></div>
-        <div><%= get_fullname(current_customer) %></div>
-        <div>
-          <%= f.radio_button :send_address, 1, {id: "radio_button_send_address_1"} %>
-          <%= f.label :send_address, "登録済住所から選択", {value: 1, style: "display: inline-block;"} %>
-        </div>
-        <select name="registered_address">
-          <%= @delivery_addresses.each do |delivery_addresses| %>
-            <option value=<%= delivery_addresses.id %> >
-              <%= delivery_addresses.post_code + " " + delivery_addresses.address + " " + delivery_addresses.name %>
-            </option>
-          <% end %>
-        </select>
-        <div>
-          <%= f.radio_button :send_address, 2, {id: "radio_button_send_address_2"} %>
-          <%= f.label :send_address, "新しいお届け先", {value: 2, style: "display: inline-block;"} %>
-        </div>
-        <div>
-          <table>
-            <tr>
-              <td><%= f.label :new_post_code, "郵便番号(ハイフンなし)" %></td>
-              <td><%= f.text_field :new_post_code, class: "form-control" %></td>
-            </tr>
-            <tr>
-              <td><%= f.label :new_address, "住所" %></td>
-              <td><%= f.text_field :new_address, class: "form-control" %></td>
-            </tr>
-            <tr>
-              <td><%= f.label :new_name, "宛先" %></td>
-              <td><%= f.text_field :new_name, class: "form-control" %></td>
-            </tr>
-          </table>
-        </div>
-      </div>
-    </div>
-    <div class='row mt-3'>
-      <div class='col-12'>
-        <div class='text-center'>
-          <%= f.submit "確認画面へ進む", class: "btn btn-primary" %>
-        </div>
-      </div>
-    </div>
+  </div>
   <% end %>
 </div>

--- a/app/views/customer/orders/thanks.html.erb
+++ b/app/views/customer/orders/thanks.html.erb
@@ -1,8 +1,21 @@
 <div class="container">
-  <div class='row'>
-    <div class='col'>
-      <div class="d-flex align-items-center justify-content-center">
-        <h4>ご購入ありがとうございました！</h4>
+  <div class='row-mt-3'>
+    <div class='col-md-12'>
+      <div class="c-order-thanks">
+        <div class="c-order-thanks-title">
+          <h4>ご購入ありがとうございます</h4>
+        </div>
+        
+
+        <div class="c-order-thanks-title-sav">
+          <h5>この度は、数あるショップの中から当店をお選びいただき </br>
+            誠にありがとうございました。</br>
+            変わらぬおいしさを皆様に味わっていただくため</br>
+            丹精込めて製造いたします。</br>
+            発送まで今しばらくお待ちくだいませ。
+          </h5>
+        </div>
+
       </div>
     </div>
   </div>


### PR DESCRIPTION


### 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
注文確認画面
<img width="1440" alt="スクリーンショット 2020-12-20 20 59 35" src="https://user-images.githubusercontent.com/71075728/102712677-474c9c80-4306-11eb-90c5-c668aed449c4.png">
<img width="1437" alt="スクリーンショット 2020-12-20 21 51 46" src="https://user-images.githubusercontent.com/71075728/102713716-921de280-430d-11eb-8b7c-6b0faefd3f0a.png">
### 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
注文確認画面⇨テーブルの配色。ボタンの色
注文完了画面⇨文章とレイアウト