### PR TITLE
[Update]配送先住所一覧画面レイアウト編集

### DIFF
--- a/app/assets/stylesheets/customer/delivery_addresses.scss
+++ b/app/assets/stylesheets/customer/delivery_addresses.scss
@@ -1,3 +1,33 @@
 // Place all the styles related to the customer::deliveryAddresses controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+.c-delivery-address-button{
+  display: inline-block;
+  border-radius: 5%;
+  /* 角丸       */
+  font-size: 12pt;
+  /* 文字サイズ */
+  text-align: center;
+  /* 文字位置   */
+  cursor: pointer;
+  /* カーソル   */
+  padding: 9px 33px;
+  /* 余白       */
+  background: #000000;
+  /* 背景色     */
+  color: #C8A06B;
+  /* 文字色     */
+  line-height: 1em;
+  /* 1行の高さ  */
+  transition: .3s;
+  /* なめらか変化 */
+
+}
+.c-delivery-address-list-name{
+  background:#000000;
+  color: #C8A06B;
+}
+.c-delivery-address-list-text{
+  background-color:#EDE1D1;
+
+}

--- a/app/views/customer/delivery_addresses/_address-list.html.erb
+++ b/app/views/customer/delivery_addresses/_address-list.html.erb
@@ -1,6 +1,6 @@
 <table class="table mt-5">
   <thead>
-    <tr>
+    <tr class="c-delivery-address-list-name">
       <th scope="col" class="w-25">郵便番号</th>
       <th scope="col" class="w-25">住所</th>
       <th scope="col" class="w-25">宛名</th>
@@ -10,12 +10,12 @@
   </thead>
   <tbody>
     <% delivery_addresses.each do |delivery_address| %>
-      <tr>
+      <tr class="c-delivery-address-list-text">
         <td><%= delivery_address.post_code %></td>
         <td><%= delivery_address.address %></td>
         <td><%= delivery_address.name %></td>
-        <td><%= link_to "編集", edit_delivery_address_path(delivery_address.id), class: "btn btn-primary" %></td>
-        <td><%= link_to "削除", delivery_address_path(delivery_address.id), method: :delete, class: "btn btn-danger", data: {confirm: "本当に削除しますか？"} %></td>
+        <td><%= link_to "編集", edit_delivery_address_path(delivery_address.id), class: "c-delivery-address-button" %></td>
+        <td><%= link_to "削除", delivery_address_path(delivery_address.id), method: :delete, class: "c-delivery-address-button", data: {confirm: "本当に削除しますか？"} %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/customer/delivery_addresses/index.html.erb
+++ b/app/views/customer/delivery_addresses/index.html.erb
@@ -29,7 +29,7 @@
         <div class="container mt-3">
           <div class="row justify-content-center">
             <div class="text-center col-5">
-              <%= f.submit "登録する", class: "btn btn-success" %>
+              <%= f.submit "登録する", class: "c-delivery-address-button" %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#73 
配送先住所一覧画面を変更しました
### 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

<img width="1403" alt="スクリーンショット 2020-12-20 22 27 07" src="https://user-images.githubusercontent.com/71075728/102714536-81bc3680-4312-11eb-9323-2ff21e1915a6.png">

