### PR TITLE
[Update]管理者ログイン

### DIFF
--- a/app/assets/stylesheets/admin/sessions.scss
+++ b/app/assets/stylesheets/admin/sessions.scss
@@ -1,0 +1,21 @@
+.c-sessions-button{
+  display: inline-block;
+  border-radius: 5%;
+  /* 角丸       */
+  font-size: 12pt;
+  /* 文字サイズ */
+  text-align: center;
+  /* 文字位置   */
+  cursor: pointer;
+  /* カーソル   */
+  padding: 9px 33px;
+  /* 余白       */
+  background: #000000;
+  /* 背景色     */
+  color: #C8A06B;
+  /* 文字色     */
+  line-height: 1em;
+  /* 1行の高さ  */
+  transition: .3s;
+  /* なめらか変化 */
+}

--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -3,7 +3,7 @@
 <%= form_with model: @admin, url: admin_session_path, local: true do |f| %>
   <div class="container">
     <div class="row mt-5 ml-5">
-      <h4 class="bg-warning">管理者ログイン<h4>
+      <h4>管理者ログイン<h4>
     </div>
 
     <div class="row">
@@ -23,7 +23,7 @@
 
     <div class="row">
       <div class="col-lg-12 col-sm-12 text-center mt-4">
-        <%= f.submit "ログイン", class: "btn btn-primary btn-lg w-25" %>
+        <%= f.submit "ログイン", class: "c-sessions-button w-25" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->
#82 
### 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
管理者ログイン画面のログインボタンの配色を変更しました
<img width="1439" alt="スクリーンショット 2020-12-21 0 43 24" src="https://user-images.githubusercontent.com/71075728/102717427-8dfdbf00-4325-11eb-8e48-346c83501f73.png">
