### PR TITLE
[fix]画像アップロードプレビューのバグ修正及びアップロード画像の表示体裁修正

### DIFF
--- a/app/assets/javascripts/image_uplode.js
+++ b/app/assets/javascripts/image_uplode.js
@@ -1,17 +1,18 @@
-$(function () {
-  // inputのidから情報の取得
-  $('#product-image').on('change', function (e) {
-  // ここから既存の画像のurlの取得
+document.addEventListener('turbolinks:load', function(){
+    // ここにjQueryの処理を記述する
+    // inputのidから情報の取得
+    $('#product-image').on('change', function (e) {
+    // ここから既存の画像のurlの取得
     console.log("image upload is clicked")
     var reader = new FileReader();
     reader.onload = function (e) {
         $("#image").attr('src', e.target.result);
     }
-  // ここまで
+    // ここまで
     reader.readAsDataURL(e.target.files[0]); //取得したurlにアップロード画像のurlを挿入
-  });
+    });
 
-  $('#product-img').on('change', function (e) {
+    $('#product-img').on('change', function (e) {
     // ここから既存の画像のurlの取得
     console.log("image upload is clicked")
     var reader = new FileReader();
@@ -20,5 +21,5 @@ $(function () {
     }
     // ここまで
     reader.readAsDataURL(e.target.files[0]); //取得したurlにアップロード画像のurlを挿入
-  });
-});
+    });
+})

--- a/app/assets/stylesheets/admin/products.scss
+++ b/app/assets/stylesheets/admin/products.scss
@@ -56,12 +56,19 @@
 // 商品詳細
 .a-product-image-wrapper {
   width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 .a-product-image-btn-wrapper {
+  margin-top: 20px;
   padding: 8px;
   display: flex;
   justify-content: center;
+}
+
+.a-product-image-content {
+  width: 300px;
 }
 
 .a-product-image-btn {
@@ -94,7 +101,7 @@
 }
 
 .a-product-register-btn-wrapper {
-  margin-top: 16px;
+  margin-top: 20px;
   padding: 8px;
   display: flex;
   justify-content: center;

--- a/app/views/admin/products/edit.html.erb
+++ b/app/views/admin/products/edit.html.erb
@@ -5,50 +5,50 @@
       <h3 class="a-product-title">商品編集</h3>
     </div>
   </div>
-  <div class="row">
-    <%= form_with model: @product, url: admin_product_path, local:true do |f| %>
-      <div class="row">
-        <div class="col-md-6">
-          <div class="a-product-image-wrapper">
+  <%= form_with model: @product, url: admin_product_path, local:true do |f| %>
+    <div class="row">
+      <div class="col-md-6">
+        <div class="a-product-image-wrapper">
+          <div class="a-product-image-content">
             <%= attachment_image_tag @product, :image, fallback: "sample_cake2.jpg", id: "img", class: "img-fluid" %>
-            <div class="a-product-image-btn-wrapper">
-              <div class="a-product-image-btn">
-                画像アップロード
-                <%= f.attachment_field :image, placeholder: "商品画像", id: 'product-img' %>
-              </div>
-            </div>
           </div>
         </div>
-        <div class="col-md-5 offset-md-1">
-          <table class="table table-borderless">
-            <tbody>
-              <tr>
-                <td><label>商品名</label></td>
-                <td><%= f.text_field :name, autofocus: true, class: "form-control a-product-input" %></td>
-              </tr>
-              <tr>
-                <td><label>商品説明</label></td>
-                <td><%= f.text_area :introduction, autofocus: true, class: "form-control a-product-input" %></td>
-              </tr>
-              <tr>
-                <td><label>ジャンル</label></td>
-                <td><%= f.select :genre_id, @genres.map{ |genre| [genre.name, genre.id] }, { include_blank: "--選択してください--" }, { class: "form-control a-product-select" } %></td>
-              </tr>
-              <tr>
-                <td><label>税抜き価格</label></td>
-                <td><%= f.text_field :price, autofocus: true, class: "form-control a-product-input" %></td>
-              </tr>
-              <tr>
-                <td><label>販売ステータス</label></td>
-                <td><%= f.select :on_sale_status, [["販売中", TRUE],["売り切れ", FALSE]], { include_blank: "--選択してください--" }, { class: "form-control a-product-select" } %></td>
-              </tr>
-            </tbody>
-          </table>
+        <div class="a-product-image-btn-wrapper">
+          <div class="a-product-image-btn">
+            画像アップロード
+            <%= f.attachment_field :image, placeholder: "商品画像", id: 'product-img' %>
+          </div>
         </div>
       </div>
-      <div class="a-product-register-btn-wrapper">
-        <%= f.submit '変更を保存',class: "a-product-button"%>
+      <div class="col-md-5">
+        <table class="table table-borderless">
+          <tbody>
+            <tr>
+              <td><label>商品名</label></td>
+              <td><%= f.text_field :name, autofocus: true, class: "form-control a-product-input" %></td>
+            </tr>
+            <tr>
+              <td><label>商品説明</label></td>
+              <td><%= f.text_area :introduction, autofocus: true, class: "form-control a-product-input" %></td>
+            </tr>
+            <tr>
+              <td><label>ジャンル</label></td>
+              <td><%= f.select :genre_id, @genres.map{ |genre| [genre.name, genre.id] }, { include_blank: "--選択してください--" }, { class: "form-control a-product-select" } %></td>
+            </tr>
+            <tr>
+              <td><label>税抜き価格</label></td>
+              <td><%= f.text_field :price, autofocus: true, class: "form-control a-product-input" %></td>
+            </tr>
+            <tr>
+              <td><label>販売ステータス</label></td>
+              <td><%= f.select :on_sale_status, [["販売中", TRUE],["売り切れ", FALSE]], { include_blank: "--選択してください--" }, { class: "form-control a-product-select" } %></td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-    <% end %>
-  </div>
+    </div>
+    <div class="a-product-register-btn-wrapper">
+      <%= f.submit '変更を保存',class: "a-product-button"%>
+    </div>
+  <% end %>
 </div>

--- a/app/views/admin/products/new.html.erb
+++ b/app/views/admin/products/new.html.erb
@@ -5,50 +5,50 @@
       <h3 class="a-product-title">商品新規登録</h3>
     </div>
   </div>
-  <div class="row">
-    <%= form_with model: @product, url: admin_products_path, local:true do |f| %>
-      <div class="row">
-        <div class="col-md-6">
-          <div class="a-product-image-wrapper">
+  <%= form_with model: @product, url: admin_products_path, local:true do |f| %>
+    <div class="row">
+      <div class="col-md-6">
+        <div class="a-product-image-wrapper">
+          <div class="a-product-image-content">
             <%= attachment_image_tag @product, :image, fallback: "sample_cake2.jpg", id: "img", class: "img-fluid" %>
-            <div class="a-product-image-btn-wrapper">
-              <div class="a-product-image-btn">
-                画像アップロード
-                <%= f.attachment_field :image, placeholder: "商品画像", id: 'product-img' %>
-              </div>
-            </div>
           </div>
         </div>
-        <div class="col-md-5 offset-md-1">
-          <table class="table table-borderless">
-            <tbody>
-              <tr>
-                <td><label>商品名</label></td>
-                <td><%= f.text_field :name, autofocus: true, class: "form-control a-product-input" %></td>
-              </tr>
-              <tr>
-                <td><label>商品説明</label></td>
-                <td><%= f.text_area :introduction, autofocus: true, class: "form-control a-product-input" %></td>
-              </tr>
-              <tr>
-                <td><label>ジャンル</label></td>
-                <td><%= f.select :genre_id, @genres.map{ |genre| [genre.name, genre.id] }, { include_blank: "--選択してください--" }, { class: "form-control a-product-select" } %></td>
-              </tr>
-              <tr>
-                <td><label>税抜き価格</label></td>
-                <td><%= f.text_field :price, autofocus: true, class: "form-control a-product-input" %></td>
-              </tr>
-              <tr>
-                <td><label>販売ステータス</label></td>
-                <td><%= f.select :on_sale_status, [["販売中", TRUE],["売り切れ", FALSE]], { include_blank: "--選択してください--" }, { class: "form-control a-product-select" } %></td>
-              </tr>
-            </tbody>
-          </table>
+        <div class="a-product-image-btn-wrapper">
+          <div class="a-product-image-btn">
+            画像アップロード
+            <%= f.attachment_field :image, placeholder: "商品画像", id: 'product-img' %>
+          </div>
         </div>
       </div>
-      <div class="a-product-register-btn-wrapper">
-        <%= f.submit '新規登録',class: "a-product-button"%>
+      <div class="col-md-5">
+        <table class="table table-borderless">
+          <tbody>
+            <tr>
+              <td><label>商品名</label></td>
+              <td><%= f.text_field :name, autofocus: true, class: "form-control a-product-input" %></td>
+            </tr>
+            <tr>
+              <td><label>商品説明</label></td>
+              <td><%= f.text_area :introduction, autofocus: true, class: "form-control a-product-input" %></td>
+            </tr>
+            <tr>
+              <td><label>ジャンル</label></td>
+              <td><%= f.select :genre_id, @genres.map{ |genre| [genre.name, genre.id] }, { include_blank: "--選択してください--" }, { class: "form-control a-product-select" } %></td>
+            </tr>
+            <tr>
+              <td><label>税抜き価格</label></td>
+              <td><%= f.text_field :price, autofocus: true, class: "form-control a-product-input" %></td>
+            </tr>
+            <tr>
+              <td><label>販売ステータス</label></td>
+              <td><%= f.select :on_sale_status, [["販売中", TRUE],["売り切れ", FALSE]], { include_blank: "--選択してください--" }, { class: "form-control a-product-select" } %></td>
+            </tr>
+          </tbody>
+        </table>
       </div>
-    <% end %>
-  </div>
+    </div>
+    <div class="a-product-register-btn-wrapper">
+      <%= f.submit '新規登録',class: "a-product-button"%>
+    </div>
+  <% end %>
 </div>

--- a/app/views/admin/products/show.html.erb
+++ b/app/views/admin/products/show.html.erb
@@ -4,47 +4,48 @@
       <h3 class="a-product-title">商品詳細</h3>
     </div>
   </div>
+  
   <div class="row">
-    <div class="row">
-      <div class="col-md-6">
-        <div class="a-product-image-wrapper">
+    <div class="col-md-6">
+      <div class="a-product-image-wrapper">
+        <div class="a-product-image-content">
           <%= attachment_image_tag @product, :image, fallback: "sample_cake2.jpg", id: "img", class: "img-fluid" %>
         </div>
       </div>
-      <div class="col-md-6">
-        <table class="table">
-          <tbody class="a-product-index-tbody">
-            <tr>
-              <td width="120" class="a-product-index-text">商品名</td>
-              <td><%= @product.name %></td>
-            </tr>
-            <tr>
-              <td width="120" class="a-product-index-text">商品説明</td>
-              <td><%= @product.introduction %></td>
-            </tr>
-            <tr>
-              <td width="120" class="a-product-index-text">ジャンル</td>
-              <td><%= @product.genre.name %></td>
-            </tr>
-            <tr>
-              <td width="120" class="a-product-index-text">税込価格(税抜価格)</td>
-              <td><%= tax(@product.price) %>(<%= converting_to_jpy(@product.price) %>)円</td>
-            </tr>
-            <tr>
-              <td width="120" class="a-product-index-text">販売ステータス</td>
-              <td>
-                <% if @product.on_sale_status == TRUE %>
-                  <%= "販売中" %>
-                <% else %>
-                  <%= "売切れ" %>
-                <% end %>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <div class="a-product-register-btn-wrapper">
-          <%= link_to '編集する',  edit_admin_product_path(@product), class: "a-product-button"%>
-        </div>
+    </div>
+    <div class="col-md-6">
+      <table class="table">
+        <tbody class="a-product-index-tbody">
+          <tr>
+            <td width="120" class="a-product-index-text">商品名</td>
+            <td><%= @product.name %></td>
+          </tr>
+          <tr>
+            <td width="120" class="a-product-index-text">商品説明</td>
+            <td><%= @product.introduction %></td>
+          </tr>
+          <tr>
+            <td width="120" class="a-product-index-text">ジャンル</td>
+            <td><%= @product.genre.name %></td>
+          </tr>
+          <tr>
+            <td width="120" class="a-product-index-text">税込価格(税抜価格)</td>
+            <td><%= tax(@product.price) %>(<%= converting_to_jpy(@product.price) %>)円</td>
+          </tr>
+          <tr>
+            <td width="120" class="a-product-index-text">販売ステータス</td>
+            <td>
+              <% if @product.on_sale_status == TRUE %>
+                <%= "販売中" %>
+              <% else %>
+                <%= "売切れ" %>
+              <% end %>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="a-product-register-btn-wrapper">
+        <%= link_to '編集する',  edit_admin_product_path(@product), class: "a-product-button"%>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->

画像アップローダーにおいてページをリロードしないとjQueryが発火せず画像プレビューが表示できない問題があったのでこれを修正した。

### 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- jQueryにおいてTurbolinksを読み込んだ後に処理するように修正
- 画像プレビューがきれいに表示されるように体裁を修正

### 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
